### PR TITLE
feat: ✨ many features and qol fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
         uses: ./action/
         with:
           library-path: lemlib
+      - name: Test print PATH
+        run: echo $PATH
 
   test-lemlib-without-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,6 @@ jobs:
         uses: ./action/
         with:
           library-path: lemlib
-      - name: Test print PATH
-        run: echo $PATH
 
   test-lemlib-without-upload:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,8 @@ runs:
         PATH="$PATH:$GITHUB_ACTION_PATH/pros-fake/bin"
         
         # give an extra flag to our pros c create-template command by by giving the Makefile an environment variable
-        CREATE_TEMPLATE_FLAGS="--no-compress"
+        CREATE_TEMPLATE_FLAGS="--no-compress --destination template"
+        export CREATE_TEMPLATE_FLAGS
         
         make template
 

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,9 @@ runs:
         # fake pros c create-template for make template
         PATH="$PATH:$GITHUB_ACTION_PATH/pros-fake/bin"
         
+        # give an extra flag to our pros c create-template command by by giving the Makefile an environment variable
+        CREATE_TEMPLATE_FLAGS="--no-compress"
+        
         make template
 
         mkdir -p template/include/"${{inputs.library-path}}"/
@@ -89,11 +92,11 @@ runs:
         perl -i -pe 's@(?<=[^/])(docs/assets/.*?)(?=[")])@${{github.server_url}}/${{github.repository}}/blob/master/$1?raw=true@g' template/include/"${{inputs.library-path}}"/README.md
         echo ${{steps.project-info.outputs.postfix}} >> template/include/${{inputs.library-path}}/VERSION
 
-    - name: Unzip Template
-      if: ${{ steps.template.outputs.template == 1 && inputs.library-path != null }}
-      uses: montudor/action-zip@v1.0.0
-      with:
-        args: unzip "${{steps.project-info.outputs.name}}.zip" -d template
+    # - name: Unzip Template
+    #   if: ${{ steps.template.outputs.template == 1 && inputs.library-path != null }}
+    #   uses: montudor/action-zip@v1.0.0
+    #   with:
+    #     args: unzip "${{steps.project-info.outputs.name}}.zip" -d template
 
     - name: Upload Artifact
       if: ${{ steps.template.outputs.template == 1 && inputs.library-path != null }}

--- a/pros-fake/bin/pros
+++ b/pros-fake/bin/pros
@@ -2,6 +2,9 @@
 index=0
 is_system_arg=0
 is_target_arg=0
+is_kernel_arg=0
+is_destination_arg=0
+is_log_level_arg=0
 
 system_files=''
 
@@ -9,7 +12,13 @@ path=''
 name=''
 version=''
 target=''
-debug=0
+destination=''
+supported_kernels=''
+
+# the lowest level of logging, can be one of:
+possible_log_levels=("DEBUG" "INFO" "WARN" "ERROR")
+log_level="INFO"
+
 # if set, tells this script to not zip the template, and instead place it in a directory
 # specified with --no-compress
 no_zip=0
@@ -17,20 +26,55 @@ no_zip=0
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
 PURPLE='\033[0;35m'
+BLUE='\033[0;34m'
 RESET='\033[0m'
 
+translate_log_level() {
+    case "$1" in
+        DEBUG) echo 0 ;;
+        INFO) echo 1 ;;
+        WARN) echo 2 ;;
+        ERROR) echo 3 ;;
+        *) echo -1 ;;
+    esac
+}
+
+is_level_enabled() {
+    # will return 1 if this log level is enabled
+    level=$(translate_log_level "$1")
+    # the current log level in integer form
+    current=$(translate_log_level "$log_level")
+    # echo "$level >= $current" >/dev/stdout
+    if [ $level -ge $current ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
 debug_echo() {
-  if [ $debug -eq 1 ]; then
-    echo "$PURPLE[DEBUG]$RESET" $@
-  fi
+    if [ "$(is_level_enabled "DEBUG")" -eq 1 ]; then
+        echo -e "$PURPLE[DEBUG]$RESET" $@
+    fi
 }
 
 error_echo() {
-  echo -e "$RED[ERROR]$RESET" $@ >&2
+    if [ "$(is_level_enabled "ERROR")" -eq 1 ]; then
+        echo -e "$RED[ERROR]$RESET" $@ >&2
+    fi
 }
 
 warning_echo() {
-  echo -e "$YELLOW[WARN]$RESET" $@ >&2
+    if [ "$(is_level_enabled "WARN")" -eq 1 ]; then
+        echo -e "$YELLOW[WARN]$RESET" $@ >&2
+    fi
+    
+}
+
+info_echo() {
+    if [ "$(is_level_enabled "INFO")" -eq 1 ]; then
+        echo -e "$BLUE[INFO]$RESET" $@
+    fi
 }
 
 newline="
@@ -49,10 +93,35 @@ for arg in "$@"; do
   if [ $is_target_arg -eq 1 ]; then
     target="$arg"
     if [ "$target" != "v5" -a "$target" != "cortex" ]; then
-      echo "target must be of type v5 or cortex. Got: $target"
-      exit 1
+      error_echo "target must be of type v5 or cortex. Got: $target"
+      exit 5
     fi
-    is_system_arg=0
+    is_target_arg=0
+    continue
+  fi
+
+  if [ $is_kernel_arg -eq 1 ]; then
+    supported_kernels="$arg"
+    is_kernel_arg=0
+    continue
+  fi
+
+  if [ $is_destination_arg -eq 1 ]; then
+    destination="$arg"
+    is_destination_arg=0
+    continue
+  fi
+
+  if [ $is_log_level_arg -eq 1 ]; then
+    # check if the log level is valid
+    new_log_level=$(echo "${possible_log_levels[@]}" | xargs -n 1 | grep -iF "$arg")
+    if [ -z new_log_level ]; then
+      error_echo "Invalid log level: $arg"
+      exit 5
+    fi
+
+    log_level="$new_log_level"
+    is_log_level_arg=0
     continue
   fi
 
@@ -66,38 +135,56 @@ for arg in "$@"; do
     continue
   fi
 
-  if [ "$arg" == "--debug" ]; then
-    debug=1
+  if [ "$arg" == "--kernels" ]; then
+    is_kernel_arg=1
+    continue
+  fi
+
+  if [ "$arg" == "--destination" ]; then
+    is_destination_arg=1
+    continue
+  fi
+
+  if [ "$arg" == "--level" ]; then
+    is_log_level_arg=1
     continue
   fi
 
   if [ "$arg" == "--no-compress" ]; then
-    debug=1
+    no_zip=1
     continue
   fi
 
+  if [ "$arg" == "--compress" ]; then
+    no_zip=0
+    continue
+  fi
+
+
   case $index in
-  0) if [ "$arg" != "c" ]; then
-    echo "Invalid argument: $arg"
+  0) if [ "$arg" != "c" -a "$arg" != "conductor" ]; then
+    error_echo "Invalid argument: "'"'"$arg"'"'", expected c or conductor."
     exit 1
   fi ;;
   1) if [ "$arg" != "create-template" ]; then
-    echo "Invalid argument: $arg"
+    error_echo "Invalid argument: "'"'"$arg"'"'", expected create-template."
     exit 1
   fi ;;
   2) path="$arg" ;;
   3) name="$arg" ;;
   4) version="$arg" ;;
-  *) echo "Invalid argument: $arg" ;;
+  *) warning_echo "Invalid argument: $arg" ;;
   esac
 
   index=$((index + 1))
 done
 
+debug_echo "args: $@"
 debug_echo "path: $path"
 debug_echo "name: $name"
 debug_echo "version: $version"
 debug_echo "target: $target"
+debug_echo "no_zip: $no_zip"
 
 if [ -z "$path" ]; then
   error_echo "Invalid argument: path"
@@ -116,27 +203,40 @@ if [ -z "$target" ]; then
   exit 1
 fi
 
-destination="./$name@$version"
+if [ -z "$destination" ]; then
+  destination="./$name@$version"
 
-if [ $no_zip -eq 0 ]; then 
-  destination="$destination.zip"
+  if [ $no_zip -eq 0 ]; then
+    destination="$destination.zip"
+  fi
+elif [ $no_zip -eq 0 ]; then
+  # if the destination does not already have a file extension, the zip command will add a .zip
+  # in order to prevent things breaking (clearing the destination beforehand for example), we'll do it proactively
+  if echo "$destination" | grep -vF "."; then
+    destination="$destination.zip"
+  fi
 fi
 
 debug_echo "destination: $destination"
 
-kernel_version=$(cat "$path/project.pros" | jq -r '.["py/state"].templates?.kernel.version')
-
-if [ "$kernel_version" != "null" ]; then
-  kernel_version="^$kernel_version";
+if [ -z "$supported_kernels" ]; then
+  supported_kernels=$(cat "$path/project.pros" | jq --raw-output '.["py/state"].templates?.kernel.version')
+  if [ "$supported_kernels" != "null" ]; then
+    supported_kernels="^$supported_kernels";
+  fi
 fi
 
-debug_echo "kernel_version: $kernel_version";
+debug_echo "supported_kernels: $supported_kernels";
 
 # sort and remove duplicates
 system_files=$(echo "$system_files" | sort | uniq)
 
 # remove destination if it exists
-rm -f "$destination"
+rm --force --recursive "$destination"
+
+if [ $no_zip -eq 1 ]; then
+  mkdir --parents "$destination"
+fi
 
 # will be deleted after zipping
 tmp_files=""
@@ -169,33 +269,46 @@ old_files=""
 
 parse_zip_output() {
   local old_files=$(echo "$old_files" | sed 's%\./%%g')
+  local new_files=$(echo "$new_files" | sed 's%\./%%g')
   function parse_zip_output_line() {
     file=$(echo "$@" \
       | sed "s/adding: //" \
       | sed -E "s/\([^()]+\)//" \
       | xargs) # trims whitespace
-    
+
     index=$(find_index "$file" "$new_files")
 
     if [ "$index" = "-1" ]; then
       error_echo "File not found: $file"
       exit 4
     fi
-    
+
     old_file=$(get_at_index "$index" "$old_files")
 
     if [ "$old_file" != "$file" ]; then
-      echo "S: $old_file -> $file"
+      info_echo "S: $old_file -> $file"
     else
-      echo "S: $file"
+      info_echo "S: $file"
     fi
   }
+  debug_echo "new_files: $new_files"
+  debug_echo "old_files: $old_files"
   export -f parse_zip_output_line
   export -f get_at_index
   export -f find_index
+  export -f error_echo
+  export -f info_echo
+  export -f is_level_enabled
+  export -f translate_log_level
+  export log_level
   export new_files
   export old_files
-  xargs -I{} bash -c 'parse_zip_output_line "$@"' _ {}
+  export RED
+  export YELLOW
+  export PURPLE
+  export BLUE
+  export RESET
+  sed 's%\./%%g' | xargs -I{} bash -c 'parse_zip_output_line "$@"' _ {}
 }
 
 tmp_dir="/tmp/pros-fake"
@@ -205,7 +318,7 @@ add_tmp_file "$tmp_dir"
 
 # ensures that tmp files are deleted
 cleanup() {
-  debug_echo "Cleaning up: $tmp_files" 
+  debug_echo "Cleaning up: $tmp_files"
   rm -Rf $tmp_files
 }
 
@@ -216,7 +329,7 @@ add_to_zip() {
   old_path="$1"
   new_path="$2"
   is_tmp="$3"
-  
+
   if [ -z "$new_path" ]; then
     new_path="$old_path"
     if [ -z "$is_tmp" ]; then
@@ -226,7 +339,7 @@ add_to_zip() {
     if [ -z "$is_tmp" ]; then
       if [ ! -e "$new_path" ]; then
         is_tmp=1
-        cp "$old_path" "$new_path" 
+        cp "$old_path" "$new_path"
       fi
     fi
   fi
@@ -246,7 +359,7 @@ system_files_strings=""
 for path in $system_files; do
   # should only be different from $path if it is inside bin
   new_path=$(echo "$path" | sed 's/\.\/bin/\.\/firmware/')
-  
+
   # if is bin, copy file into firmware
   if [ "$path" != "$new_path" ]; then
     if [ -e "$new_path" ]; then
@@ -260,7 +373,7 @@ for path in $system_files; do
       continue
     fi
   fi
-  
+
   add_to_zip "$path" "$new_path"
 
   system_files_strings="$system_files_strings"'"'"$new_path"'"'"$newline"
@@ -270,13 +383,20 @@ system_files_json="$(echo "$system_files_strings" | jq --slurp --compact-output 
 
 template_pros_target="$tmp_dir/template.pros"
 
+if [ $no_zip -eq 1 ]; then
+  template_pros_target="$destination/template.pros"
+fi
+
 if [ $no_zip -eq 0 ]; then
   zip -9 "$destination" $new_files | parse_zip_output;
 else
-  cp -t "$destination" $new_files --verbose \
-    | sed 's/->.+//' \
-    | sed "s/'//" \
-    | xargs -I {} echo "adding: {} (mimic zip output)" \
+  cp --parents -t "$destination" $new_files --verbose \
+    | sed -E 's/.+->//' \
+    | sed "s/'//g" \
+    | sed "s%$destination/%%" \
+    | xargs -n 1 \
+    | xargs -d "\n" -I {} bash -c 'if [ ! -d "$1" ]; then echo "$1"; fi' _ {} \
+    | xargs -d "\n" -I {} echo "adding: {} (mimic zip output)" \
     | parse_zip_output
 fi
 
@@ -284,7 +404,7 @@ jq --null-input --tab --sort-keys \
   --arg name "$name" \
   --arg version "$version" \
   --arg target "$target" \
-  --arg kernel_version "$kernel_version" \
+  --arg supported_kernels "$supported_kernels" \
   --argjson sysfiles "$system_files_json" \
   '{
     "py/object": "pros.conductor.templates.external_template.ExternalTemplate",
@@ -292,18 +412,16 @@ jq --null-input --tab --sort-keys \
       "name": $name,
       "version": $version,
       "target": $target,
-      "supported_kernels": $kernel_version,
+      "supported_kernels": $supported_kernels,
       "system_files": $sysfiles,
       "metadata":  {},
       "user_files": []
     }
   }' > "$template_pros_target"
-add_tmp_file "$template_pros_target"
 
 if [ $no_zip -eq 0 ]; then
+  add_tmp_file "$template_pros_target"
   zip -9qj "$destination" "$template_pros_target";
-else
-  cp "$template_pros_target" "$destination";
 fi
 
 cleanup

--- a/pros-fake/bin/pros
+++ b/pros-fake/bin/pros
@@ -1,4 +1,25 @@
 #! /bin/env bash
+description="This script is a fake of the real pros-cli python program, intended only to be run in CI environments to generate PROS template zips.
+pros-fake can be found here: https://github.com/LemLib/pros-build/tree/main/pros-fake/bin/pros 
+pros-cli can be found here: https://github.com/purduesigbots/pros-cli"
+
+help_text="$description
+
+Syntax: pros-fake [options] c create-template path name version
+This is designed to be as close to the real pros-cli create-template command as possible, but some of the options are different.
+This script does not support the --user, --zip, --no-zip, --verbose, --debug, --log, --logfile options.
+Here are the extra options that this script supports:
+
+--compress      Compress the template into a zip file. This is the default behavior.
+--no-compress   Do not compress the template into a zip file. Instead, place it in a directory.
+--level LEVEL   Set the log level to LEVEL. LEVEL can be one of DEBUG, INFO, WARN, ERROR. Default is INFO."
+
+trouble_shooting_note="If you are seeing this message, something has gone wrong.
+Make sure that you're "'$PATH'" variable is set correctly.
+This script can be found at: $0
+See --help for more information."
+
+
 index=0
 is_system_arg=0
 is_target_arg=0
@@ -54,31 +75,36 @@ is_level_enabled() {
 
 debug_echo() {
     if [ "$(is_level_enabled "DEBUG")" -eq 1 ]; then
-        echo -e "$PURPLE[DEBUG]$RESET" $@
+        echo -e "$PURPLE[DEBUG]$RESET" "$@"
     fi
 }
 
 error_echo() {
     if [ "$(is_level_enabled "ERROR")" -eq 1 ]; then
-        echo -e "$RED[ERROR]$RESET" $@ >&2
+        echo -e "$RED[ERROR]$RESET" "$@" >&2
     fi
 }
 
 warning_echo() {
     if [ "$(is_level_enabled "WARN")" -eq 1 ]; then
-        echo -e "$YELLOW[WARN]$RESET" $@ >&2
+        echo -e "$YELLOW[WARN]$RESET" "$@" >&2
     fi
     
 }
 
 info_echo() {
     if [ "$(is_level_enabled "INFO")" -eq 1 ]; then
-        echo -e "$BLUE[INFO]$RESET" $@
+        echo -e "$BLUE[INFO]$RESET" "$@"
     fi
 }
 
 newline="
 "
+
+if [ $# -eq 0 ]; then
+  error_echo "No arguments provided. See --help for more information."
+  exit 6
+fi
 
 for arg in "$@"; do
   if [ $is_system_arg -eq 1 ]; then
@@ -125,6 +151,11 @@ for arg in "$@"; do
     continue
   fi
 
+  if [ "$arg" == "--help" ]; then
+    echo -e "$help_text"
+    exit 0
+  fi
+
   if [ "$arg" == "--system" ]; then
     is_system_arg=1
     continue
@@ -163,11 +194,19 @@ for arg in "$@"; do
 
   case $index in
   0) if [ "$arg" != "c" -a "$arg" != "conductor" ]; then
-    error_echo "Invalid argument: "'"'"$arg"'"'", expected c or conductor."
+    error_echo "Invalid argument: "'"'"$arg"'"'", expected c or conductor.
+This is likely because $description
+
+Troubleshooting:
+$trouble_shooting_note"
     exit 1
   fi ;;
   1) if [ "$arg" != "create-template" ]; then
-    error_echo "Invalid argument: "'"'"$arg"'"'", expected create-template."
+    error_echo "Invalid argument: "'"'"$arg"'"'", expected create-template.
+This is likely because $description
+
+Troubleshooting:
+$trouble_shooting_note"
     exit 1
   fi ;;
   2) path="$arg" ;;

--- a/pros-fake/bin/pros
+++ b/pros-fake/bin/pros
@@ -10,6 +10,9 @@ name=''
 version=''
 target=''
 debug=0
+# if set, tells this script to not zip the template, and instead place it in a directory
+# specified with --no-compress
+no_zip=0
 
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
@@ -68,6 +71,11 @@ for arg in "$@"; do
     continue
   fi
 
+  if [ "$arg" == "--no-compress" ]; then
+    debug=1
+    continue
+  fi
+
   case $index in
   0) if [ "$arg" != "c" ]; then
     echo "Invalid argument: $arg"
@@ -108,7 +116,12 @@ if [ -z "$target" ]; then
   exit 1
 fi
 
-destination="./$name@$version.zip"
+destination="./$name@$version"
+
+if [ $no_zip -eq 0 ]; then 
+  destination="$destination.zip"
+fi
+
 debug_echo "destination: $destination"
 
 kernel_version=$(cat "$path/project.pros" | jq -r '.["py/state"].templates?.kernel.version')
@@ -257,7 +270,15 @@ system_files_json="$(echo "$system_files_strings" | jq --slurp --compact-output 
 
 template_pros_target="$tmp_dir/template.pros"
 
-zip -9 "$destination" $new_files | parse_zip_output
+if [ $no_zip -eq 0 ]; then
+  zip -9 "$destination" $new_files | parse_zip_output;
+else
+  cp -t "$destination" $new_files --verbose \
+    | sed 's/->.+//' \
+    | sed "s/'//"
+    | xargs -I {} echo "adding: {} (mimic zip output)"
+    | parse_zip_output
+fi
 
 jq --null-input --tab --sort-keys \
   --arg name "$name" \
@@ -279,6 +300,10 @@ jq --null-input --tab --sort-keys \
   }' > "$template_pros_target"
 add_tmp_file "$template_pros_target"
 
-zip -9qj "$destination" "$template_pros_target"
+if [ $no_zip -eq 0 ]; then
+  zip -9qj "$destination" "$template_pros_target";
+else
+  cp "$template_pros_target" "$destination";
+fi
 
 cleanup

--- a/pros-fake/bin/pros
+++ b/pros-fake/bin/pros
@@ -119,7 +119,7 @@ for arg in "$@"; do
   if [ $is_target_arg -eq 1 ]; then
     target="$arg"
     if [ "$target" != "v5" -a "$target" != "cortex" ]; then
-      error_echo "target must be of type v5 or cortex. Got: $target"
+      error_echo "target must be of type v5 or cortex. Got: "'"'"$target"'"'", see --help for more information."
       exit 5
     fi
     is_target_arg=0
@@ -142,7 +142,7 @@ for arg in "$@"; do
     # check if the log level is valid
     new_log_level=$(echo "${possible_log_levels[@]}" | xargs -n 1 | grep -iF "$arg")
     if [ -z new_log_level ]; then
-      error_echo "Invalid log level: $arg"
+      error_echo "Invalid log level: "'"'"$arg"'"'", see --help for more information."
       exit 5
     fi
 
@@ -191,7 +191,6 @@ for arg in "$@"; do
     continue
   fi
 
-
   case $index in
   0) if [ "$arg" != "c" -a "$arg" != "conductor" ]; then
     error_echo "Invalid argument: "'"'"$arg"'"'", expected c or conductor.
@@ -212,7 +211,7 @@ $trouble_shooting_note"
   2) path="$arg" ;;
   3) name="$arg" ;;
   4) version="$arg" ;;
-  *) warning_echo "Invalid argument: $arg" ;;
+  *) warning_echo "Invalid argument: "'"'"$arg"'"'", see --help for more information." ;;
   esac
 
   index=$((index + 1))
@@ -226,19 +225,19 @@ debug_echo "target: $target"
 debug_echo "no_zip: $no_zip"
 
 if [ -z "$path" ]; then
-  error_echo "Invalid argument: path"
+  error_echo "Invalid path argument: "'"'"$path"'"'", see --help for more information."
   exit 1
 fi
 if [ -z "$name" ]; then
-  error_echo "Invalid argument: name"
+  error_echo "Invalid name argument: "'"'"$name"'"'", see --help for more information."
   exit 1
 fi
 if [ -z "$version" ]; then
-  error_echo "Invalid argument: version"
+  error_echo "Invalid version argument: "'"'"$version"'"'", see --help for more information."
   exit 1
 fi
 if [ -z "$target" ]; then
-  error_echo "Invalid argument: target"
+  error_echo "Invalid target argument: "'"'"$target"'"'", see --help for more information."
   exit 1
 fi
 
@@ -318,7 +317,7 @@ parse_zip_output() {
     index=$(find_index "$file" "$new_files")
 
     if [ "$index" = "-1" ]; then
-      error_echo "File not found: $file"
+      error_echo "File not found: '$file'. This should not happen. Fatal error."
       exit 4
     fi
 
@@ -402,13 +401,13 @@ for path in $system_files; do
   # if is bin, copy file into firmware
   if [ "$path" != "$new_path" ]; then
     if [ -e "$new_path" ]; then
-      error_echo "File already exists: $new_path. Fatal error."
+      error_echo "File already exists: "'"'"$new_path"'"'". Fatal error."
       cleanup
       exit 2
     fi
   else
     if [ ! -f "$new_path" ]; then
-      warning_echo "File not found: $path"
+      warning_echo "File not found: "'"'"$path"'"'""
       continue
     fi
   fi

--- a/pros-fake/bin/pros
+++ b/pros-fake/bin/pros
@@ -275,8 +275,8 @@ if [ $no_zip -eq 0 ]; then
 else
   cp -t "$destination" $new_files --verbose \
     | sed 's/->.+//' \
-    | sed "s/'//"
-    | xargs -I {} echo "adding: {} (mimic zip output)"
+    | sed "s/'//" \
+    | xargs -I {} echo "adding: {} (mimic zip output)" \
     | parse_zip_output
 fi
 


### PR DESCRIPTION
- ✨ log levels
- ⚡ don't do extra zip and unzip
  - ✨ --no-compress flag to not put template in a zip
  - ✨ destination arg
  - 🔊 filter out directories when sending verbose copy output to `parse_zip_output`
  - 🐛 remove './' where ever possible in `parse_zip_output` to make everything uniform
  - ✨ add --compress flag
  - ⚡ don't put template.pros in tmp directory if we are not zipping
- ✨ supported kernels arg
- ✨ info log level
- 🐛 catch a bug where everything after --target being interpreted as a target param
- ✨ instead of just `pros c create-template ...`, `pros conductor create-template ...` also works now
- 🔊 provide useful logging for invalid subcommands
- 🔊 add more debug logs
- 🐛 ensure that if we are zipping, destination is handled properly (append `.zip` if there is not already a file extension there)
- 💄 expand out some flags to be `--word flags` rather than `-w`
- 🔊 print colors properly in `parse_zip_output`

Im worried that making this script so big might make it difficult to maintain, especially since this is intended to be a smaller project. 
lmk what you think