### PR TITLE
[README] 📃 Bump pros-build version in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run LemLib/pros-build
         id: test
-        uses: LemLib/pros-build@v2.0.1
+        uses: LemLib/pros-build@v2.0.2
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
#### Overview

Bump the pros-build version in the readme from v2.0.1 to v2.0.2

#### Motivation

Users are likely to just copy/paste the example in the readme, and as a consequence they would be using an outdated version of pros-build